### PR TITLE
Conductor position

### DIFF
--- a/rswarp/diagnostics/ConductorTemplates.py
+++ b/rswarp/diagnostics/ConductorTemplates.py
@@ -247,7 +247,7 @@ class UnstructuredPlot(Conductor):
         y = np.linspace(self.w3d.ymmin, self.w3d.ymmax, self.w3d.ny)
         z = np.linspace(self.w3d.zmmin, self.w3d.zmmax, self.w3d.nz)
 
-        X, Y, Z = np.meshgrid(x, y, z)
+        X, Y, Z = np.meshgrid(x, y, z, indexing="ij")
 
         isin = self.conductor.isinside(X.ravel(), Y.ravel(), Z.ravel())
         dat_isin = 1 - isin.isinside.reshape(X.shape)

--- a/rswarp/stlconductor/stlconductor.py
+++ b/rswarp/stlconductor/stlconductor.py
@@ -156,6 +156,22 @@ class STLconductor(Assembly):
 
         self._surface_mesh_quality_check()
 
+        # Use conductor center to shift mesh
+        bounds = self.surface.bbox
+        mesh_ctr = [
+            bounds[0][0] + (bounds[1][0] - bounds[0][0]) / 2.,
+            bounds[0][1] + (bounds[1][1] - bounds[0][1]) / 2.,
+            bounds[0][2] + (bounds[1][2] - bounds[0][2]) / 2.
+        ]
+        offsets = [
+            xcent - mesh_ctr[0],
+            ycent - mesh_ctr[1],
+            zcent - mesh_ctr[2]
+        ]
+        vertices = deepcopy(self.surface.vertices)
+        for i in range(len(offsets)): vertices[:, i] += offsets[i]
+        self.surface = pymesh.form_mesh(vertices, self.surface.faces)
+
         if disp != "none" and disp != "auto":
             try:
                 if len(np.asarray(disp)) != 3: raise StandardError("")


### PR DESCRIPTION
Added to allow the user to move stl conductors around in sirepo like any other conductor, rather than generate a new stl file.  If there's some reason that is not normally done, I will make the positions in sirepo read-only.

Also included is a change in the meshgrid indexing, which otherwise leads to crashes when nx differs from ny